### PR TITLE
Refactor

### DIFF
--- a/js/Lens.elm
+++ b/js/Lens.elm
@@ -1,0 +1,62 @@
+module Lens
+    exposing
+        ( Lens
+        , PureLens
+        , get
+        , goIn
+        , update
+        , updateIf
+        )
+
+
+type alias Lens submodel updatedSubmodel model updatedModel =
+    { get : model -> Maybe submodel
+    , set : updatedSubmodel -> model -> Maybe updatedModel
+    }
+
+
+type alias PureLens submodel model =
+    Lens submodel submodel model model
+
+
+get :
+    Lens submodel updatedSubmodel model updatedModel
+    -> model
+    -> Maybe submodel
+get { get } =
+    get
+
+
+goIn :
+    Lens submodel updatedSubmodel model updatedModel
+    -> Lens model updatedModel supermodel updatedSupermodel
+    -> Lens submodel updatedSubmodel supermodel updatedSupermodel
+goIn submodelInModel modelInSupermodel =
+    { get = modelInSupermodel.get >> Maybe.andThen submodelInModel.get
+    , set =
+        \submodel supermodel ->
+            modelInSupermodel.get supermodel
+                |> Maybe.andThen
+                    (submodelInModel.set submodel
+                        >> Maybe.andThen
+                            (flip modelInSupermodel.set supermodel)
+                    )
+    }
+
+
+update :
+    Lens submodel updatedSubmodel model updatedModel
+    -> (submodel -> updatedSubmodel)
+    -> model
+    -> Maybe updatedModel
+update { get, set } upd model =
+    get model |> Maybe.andThen (upd >> flip set model)
+
+
+updateIf :
+    Lens submodel updatedSubmodel model updatedModel
+    -> (submodel -> model -> updatedModel)
+    -> model
+    -> Maybe updatedModel
+updateIf { get } upd model =
+    get model |> Maybe.map (flip upd model)

--- a/js/Model.elm
+++ b/js/Model.elm
@@ -3,6 +3,7 @@ module Model exposing (..)
 import BaseType exposing (..)
 import Card exposing (Card)
 import Material exposing (Fruit, Material)
+import Lens exposing (PureLens)
 import Timer exposing (Timer)
 import Time exposing (Time)
 
@@ -160,39 +161,42 @@ initAuctionModel =
 -- GETTER & SETTERS
 
 
-timer : Stage -> Maybe Timer
-timer stage =
-    case stage of
-        ReadyStage _ ->
-            Nothing
+timer : PureLens Timer Stage
+timer =
+    let
+        get stage =
+            case stage of
+                ReadyStage _ ->
+                    Nothing
 
-        ProductionStage m ->
-            Just m.timer
+                ProductionStage m ->
+                    Just m.timer
 
-        AuctionStage m ->
-            m.auction |> Maybe.map .timer
+                AuctionStage m ->
+                    m.auction |> Maybe.map .timer
 
-        TradeStage m ->
-            Just m.timer
+                TradeStage m ->
+                    Just m.timer
 
+        set timer stage =
+            case stage of
+                ReadyStage _ ->
+                    Nothing
 
-updateTimer : (Timer -> Timer) -> Stage -> Stage
-updateTimer upd stage =
-    case stage of
-        ReadyStage m ->
-            stage
+                ProductionStage m ->
+                    Just <| ProductionStage { m | timer = timer }
 
-        ProductionStage m ->
-            ProductionStage { m | timer = upd m.timer }
+                TradeStage m ->
+                    Just <| TradeStage { m | timer = timer }
 
-        TradeStage m ->
-            TradeStage { m | timer = upd m.timer }
-
-        AuctionStage m ->
-            AuctionStage
-                { m
-                    | auction =
-                        Maybe.map
-                            (\a -> { a | timer = upd a.timer })
-                            m.auction
-                }
+                AuctionStage m ->
+                    Just <|
+                        AuctionStage
+                            { m
+                                | auction =
+                                    Maybe.map
+                                        (\a -> { a | timer = timer })
+                                        m.auction
+                            }
+    in
+        { get = get, set = set }

--- a/js/View.elm
+++ b/js/View.elm
@@ -4,6 +4,7 @@ import Material exposing (Material)
 import Model exposing (..)
 import Msg exposing (..)
 import Timer
+import Lens
 import Helper
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -95,7 +96,7 @@ topBar model =
         , div [ class "timer" ]
             (List.concat
                 [ case
-                    timer model.stage
+                    Lens.get timer model.stage
                   of
                     Just timer ->
                         [ div [ class "timer-text" ]


### PR DESCRIPTION
It's probably easier to understand if you review each commit individually. Some changes are just renaming: 
```
type alias Eff a = (a, Cmd Msg)
type alias Upd a = a -> (a, Cmd Msg)
model ! [ cmd ] = (model, cmd)
```
And I combined the `toServer` and `toMsg` information passed down from the parent update functions into one `Ctx` type (I needed a second `GameCtx` type because of the way things are set up on the server now with auto-joining games). 

The `Lens` in the first commit is a little harder to understand. I abstracted over the getter and setters so I can handle the errors uniformly. 