### PR TITLE
Yield rate modifier

### DIFF
--- a/js/Update.elm
+++ b/js/Update.elm
@@ -15,6 +15,7 @@ import ZoomList
 import AnimationFrame
 import Time exposing (Time)
 import Random
+import List.Nonempty as Nonempty exposing (Nonempty)
 import Debug
 
 
@@ -247,13 +248,37 @@ handleTradeMsg { toGameServer, toMsg } msg model =
                     -- [note] only makes sense for 0 <= x <= 1
                     -- mod first to generalize?
                     if x < p then
-                        ceiling x
-                    else
                         floor x
+                    else
+                        ceiling x
 
-                binary : Float -> Random.Generator Int
-                binary p =
-                    Random.float 0 1 |> Random.map (roundAt p)
+                yieldWithAvg : Float -> Random.Generator Int
+                yieldWithAvg avg =
+                    {- Write avg=n+p, where n=floor p.
+                       Yield either n or n+1 with probabilities
+                       P(n) = 1-p and P(n+1) = p.
+
+                       The average is then:
+                       n * (1-p) + (n+1) * p
+                       == n+p == avg
+                    -}
+                    let
+                        n =
+                            floor avg
+
+                        p =
+                            avg - toFloat n
+                    in
+                        Random.float 0 1
+                            |> Random.map
+                                (\s ->
+                                    if s < p then
+                                        -- this event has probability p
+                                        n + 1
+                                    else
+                                        -- this event has probability 1-p
+                                        n
+                                )
 
                 yield : Random.Generator (Material Int)
                 yield =
@@ -261,8 +286,9 @@ handleTradeMsg { toGameServer, toMsg } msg model =
                         matRandom =
                             Material.map2
                                 (always
-                                    (\p c ->
-                                        binary p
+                                    (\avg c ->
+                                        yieldWithAvg avg
+                                            -- one yield per factory
                                             |> Random.list c
                                             |> Random.map List.sum
                                     )

--- a/js/Update.elm
+++ b/js/Update.elm
@@ -15,7 +15,6 @@ import ZoomList
 import AnimationFrame
 import Time exposing (Time)
 import Random
-import List.Nonempty as Nonempty exposing (Nonempty)
 import Debug
 
 

--- a/js/elm-package.json
+++ b/js/elm-package.json
@@ -11,7 +11,8 @@
         "elm-lang/animation-frame": "1.0.1 <= v < 2.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "elm-lang/websocket": "1.0.0 <= v < 2.0.0"
+        "elm-lang/websocket": "1.0.0 <= v < 2.0.0",
+        "mgold/elm-nonempty-list": "3.1.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/js/elm-package.json
+++ b/js/elm-package.json
@@ -11,8 +11,7 @@
         "elm-lang/animation-frame": "1.0.1 <= v < 2.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "elm-lang/websocket": "1.0.0 <= v < 2.0.0",
-        "mgold/elm-nonempty-list": "3.1.0 <= v < 4.0.0"
+        "elm-lang/websocket": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
I've implemented the yield rate modifier as a `Float` (assumed to be greater than 0). It affects the yield behaviour as follows: 

Suppose the yield rate modifier for a fruit is `r = n + p`, where `n = floor p`. Then each factory of that fruit type yields `n` fruits with probability `1-p` and `n+1` fruits with probability `p`. The final yield is the sum of the yields for individual factories. This means the average yield is
```
n * (1-p) + (n+1) * p 
= n + p 
= r
```
so that the yield rate modifier tells us the average yield rate. 